### PR TITLE
Rust profile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -54,6 +69,12 @@ name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
@@ -145,9 +166,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
+ "futures-core",
  "getrandom",
  "instant",
+ "pin-project-lite",
  "rand",
+ "tokio",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.67"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
 ]
 
 [[package]]
@@ -202,6 +241,12 @@ name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+
+[[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
 name = "byteorder"
@@ -319,6 +364,15 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpp_demangle"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c76f98bdfc7f66172e6c7065f981ebb576ffc903fe4c0561d9f0c2509226dc6"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -450,6 +504,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deflate"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,6 +606,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +624,27 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -684,6 +788,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +834,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
+]
+
+[[package]]
+name = "headers"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
 ]
 
 [[package]]
@@ -913,6 +1048,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb7c1b80a1dfa604bb4a649a5c5aeef3d913f7c520cb42b40e534e8a61bcdfc"
+dependencies = [
+ "ahash 0.8.3",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -940,6 +1093,18 @@ checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 dependencies = [
  "schemars",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix 0.37.7",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1151,11 +1316,11 @@ dependencies = [
 
 [[package]]
 name = "kubert"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02666a25673a963105bf8a395aff94b8f56a2e709b99e8503ed9262c2a81a7b9"
+version = "0.16.1"
+source = "git+https://github.com/amit-62/kubert#55294c252010a0913b048d29f034671d888a41fc"
 dependencies = [
  "ahash 0.8.3",
+ "backoff",
  "chrono",
  "clap",
  "deflate",
@@ -1217,7 +1382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b18cbf29f8ff3542ba22bdce9ac610fcb75d74bb4e2b306b2a2762242025b4f"
 dependencies = [
  "bindgen",
- "errno",
+ "errno 0.2.8",
  "libc",
 ]
 
@@ -1268,6 +1433,7 @@ dependencies = [
  "linkerd-policy-controller-k8s-status",
  "openssl",
  "parking_lot",
+ "pprof",
  "serde",
  "serde_json",
  "thiserror",
@@ -1275,6 +1441,9 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "tracing-flame",
+ "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]
@@ -1413,6 +1582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1650,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memmap2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1561,10 +1745,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1576,6 +1779,36 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1596,6 +1829,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -1625,6 +1868,15 @@ checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi 0.2.6",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1727,7 +1979,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -1798,6 +2050,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
 
 [[package]]
+name = "pprof"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "196ded5d4be535690899a4631cc9f18cdc41b7ebf24a79400f46f48e49a11059"
+dependencies = [
+ "backtrace",
+ "cfg-if",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "parking_lot",
+ "protobuf",
+ "protobuf-codegen-pure",
+ "smallvec",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1846,7 +2121,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix",
+ "rustix 0.36.11",
 ]
 
 [[package]]
@@ -1882,6 +2157,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+dependencies = [
+ "protobuf",
+]
+
+[[package]]
+name = "protobuf-codegen-pure"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a29399fc94bcd3eeaa951c715f7bea69409b2445356b00519740bcd6ddd865"
+dependencies = [
+ "protobuf",
+ "protobuf-codegen",
+]
+
+[[package]]
 name = "quanta"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +2195,15 @@ dependencies = [
  "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1955,13 +2264,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "thiserror",
 ]
 
@@ -1992,6 +2310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
+name = "rgb"
+version = "0.8.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ec2d3e3fc7a92ced357df9cebd5a10b6fb2aa1ee797bf7e9ce2f17dffc8f59"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2000,7 +2327,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -2016,6 +2343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,10 +2361,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
  "windows-sys 0.45.0",
 ]
 
@@ -2112,6 +2459,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2222,6 +2575,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2306,10 +2671,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "symbolic-common"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b55cdc318ede251d0957f07afe5fed912119b8c1bc5a7804151826db999e737"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "10.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79be897be8a483a81fff6a3a4e195b4ac838ef73ca42d348b3f722da9902e489"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -2338,6 +2750,19 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.7",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "termcolor"
@@ -2628,6 +3053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-flame"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bae117ee14789185e129aaee5d93750abe67fdc5a9a62650452bfe4e122a3a9"
+dependencies = [
+ "lazy_static",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2660,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2720,6 +3156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2770,6 +3215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "uuid"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+
+[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +3246,37 @@ checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 dependencies = [
  "log",
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba431ef570df1287f7f8b07e376491ad54f84d26ac473489427231e1718e1f69"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http",
+ "hyper",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "rustls-pemfile",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2954,6 +3436,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 
 [profile.release]
 lto = "thin"
+
+[patch.crates-io]
+kubert = { git = "https://github.com/amit-62/kubert" }

--- a/bin/docker-build-policy-controller
+++ b/bin/docker-build-policy-controller
@@ -17,4 +17,4 @@ bindir=$( cd "${BASH_SOURCE[0]%/*}" && pwd )
 . "$bindir"/_os.sh
 
 dir=$( cd "$bindir"/../policy-controller && pwd )
-docker_build policy-controller "${TAG:-$(head_root_tag)}" "$dir/Dockerfile"
+docker_build policy-controller "${TAG:-$(head_root_tag)}" "$dir/Dockerfile-gnu"

--- a/charts/linkerd-control-plane/templates/destination.yaml
+++ b/charts/linkerd-control-plane/templates/destination.yaml
@@ -289,6 +289,7 @@ spec:
         - --log-level={{.Values.policyController.logLevel | default "linkerd=info,warn"}}
         - --log-format={{.Values.controllerLogFormat}}
         - --default-opaque-ports={{.Values.proxy.opaquePorts}}
+        - --enable-pprof={{.Values.enablePprof | default false}}
         {{- if .Values.policyController.probeNetworks }}
         - --probe-networks={{.Values.policyController.probeNetworks | join ","}}
         {{- end}}
@@ -306,6 +307,10 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+        {{ if .Values.enablePprof -}}  
+        - containerPort: 8081
+          name: pprof
+        {{- end }}   
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -329,6 +334,10 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+        {{ if .Values.enablePprof -}}  
+        - mountPath: /tmp
+          name: tmp 
+        {{- end }}    
       initContainers:
       {{ if .Values.cniEnabled -}}
       - {{- include "partials.network-validator" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
@@ -354,6 +363,10 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+      {{ if .Values.enablePprof -}}    
+      - name: tmp
+        emptyDir: {} 
+      {{- end }}     
       {{ if not .Values.cniEnabled -}}
       - {{- include "partials.proxyInit.volumes.xtables" . | indent 8 | trimPrefix (repeat 7 " ") }}
       {{ end -}}

--- a/cli/cmd/testdata/install_controlplane_tracing_output.golden
+++ b/cli/cmd/testdata/install_controlplane_tracing_output.golden
@@ -1384,6 +1384,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1399,6 +1400,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1419,6 +1421,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1468,6 +1471,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_custom_domain.golden
+++ b/cli/cmd/testdata/install_custom_domain.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_custom_registry.golden
+++ b/cli/cmd/testdata/install_custom_registry.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: my.custom.registry/linkerd-io/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_default.golden
+++ b/cli/cmd/testdata/install_default.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_default_override_dst_get_nets.golden
+++ b/cli/cmd/testdata/install_default_override_dst_get_nets.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_default_token.golden
+++ b/cli/cmd/testdata/install_default_token.golden
@@ -1371,6 +1371,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1386,6 +1387,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1406,6 +1408,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1455,6 +1458,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - emptyDir:

--- a/cli/cmd/testdata/install_ha_output.golden
+++ b/cli/cmd/testdata/install_ha_output.golden
@@ -1510,6 +1510,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1525,6 +1526,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1545,6 +1547,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1594,6 +1597,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_ha_with_overrides_output.golden
+++ b/cli/cmd/testdata/install_ha_with_overrides_output.golden
@@ -1510,6 +1510,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1525,6 +1526,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1545,6 +1547,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1594,6 +1597,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_heartbeat_disabled_output.golden
+++ b/cli/cmd/testdata/install_heartbeat_disabled_output.golden
@@ -1313,6 +1313,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1328,6 +1329,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1348,6 +1350,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1397,6 +1400,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_helm_control_plane_output.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output.golden
@@ -1358,6 +1358,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:linkerd-version
         imagePullPolicy: IfNotPresent
@@ -1373,6 +1374,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1393,6 +1395,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1442,6 +1445,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
+++ b/cli/cmd/testdata/install_helm_control_plane_output_ha.golden
@@ -1486,6 +1486,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:linkerd-version
         imagePullPolicy: IfNotPresent
@@ -1501,6 +1502,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1521,6 +1523,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1570,6 +1573,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_helm_output_ha_labels.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_labels.golden
@@ -1498,6 +1498,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:linkerd-version
         imagePullPolicy: IfNotPresent
@@ -1513,6 +1514,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1533,6 +1535,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1582,6 +1585,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
+++ b/cli/cmd/testdata/install_helm_output_ha_namespace_selector.golden
@@ -1476,6 +1476,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:linkerd-version
         imagePullPolicy: IfNotPresent
@@ -1491,6 +1492,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1511,6 +1513,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1560,6 +1563,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_no_init_container.golden
+++ b/cli/cmd/testdata/install_no_init_container.golden
@@ -1375,6 +1375,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1390,6 +1391,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1410,6 +1412,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - name: linkerd-network-validator
         image: cr.l5d.io/linkerd/proxy:install-proxy-version
@@ -1454,6 +1457,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - name: linkerd-identity-token
         projected:
           sources:

--- a/cli/cmd/testdata/install_output.golden
+++ b/cli/cmd/testdata/install_output.golden
@@ -1357,6 +1357,7 @@ spec:
         - --log-level=log-level
         - --log-format=ControllerLogFormat
         - --default-opaque-ports=25,443,587,3306,5432,11211
+        - --enable-pprof=false
         - --probe-networks=1.0.0.0/0,2.0.0.0/0
         image: PolicyControllerImageName:PolicyControllerVersion
         imagePullPolicy: ImagePullPolicy
@@ -1372,6 +1373,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1398,6 +1400,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1446,6 +1449,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_proxy_ignores.golden
+++ b/cli/cmd/testdata/install_proxy_ignores.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/cli/cmd/testdata/install_values_file.golden
+++ b/cli/cmd/testdata/install_values_file.golden
@@ -1382,6 +1382,7 @@ spec:
         - --log-level=info
         - --log-format=plain
         - --default-opaque-ports=25,587,3306,4444,5432,6379,9300,11211
+        - --enable-pprof=false
         - --probe-networks=0.0.0.0/0
         image: cr.l5d.io/linkerd/policy-controller:install-control-plane-version
         imagePullPolicy: IfNotPresent
@@ -1397,6 +1398,7 @@ spec:
           name: admin-http
         - containerPort: 9443
           name: policy-https
+           
         readinessProbe:
           failureThreshold: 7
           httpGet:
@@ -1417,6 +1419,7 @@ spec:
         - mountPath: /var/run/linkerd/tls
           name: policy-tls
           readOnly: true
+            
       initContainers:
       - args:
         - --incoming-proxy-port
@@ -1466,6 +1469,7 @@ spec:
       - name: policy-tls
         secret:
           secretName: linkerd-policy-validator-k8s-tls
+           
       - emptyDir: {}
         name: linkerd-proxy-init-xtables-lock
       - name: linkerd-identity-token

--- a/policy-controller/Cargo.toml
+++ b/policy-controller/Cargo.toml
@@ -11,6 +11,7 @@ openssl-tls = ["kube/openssl-tls"]
 # Vendor openssl to statically link lib
 openssl-vendored = ["openssl/vendored"]
 rustls-tls = ["kube/rustls-tls"]
+pprof = ["dep:pprof", "warp"]
 
 [dependencies]
 anyhow = "1"
@@ -33,6 +34,10 @@ serde_json = "1"
 thiserror = "1"
 tokio-stream = { version = "0.1", features = ["sync"] }
 tracing = "0.1"
+pprof = { version = "0.11", optional = true, features = ["flamegraph", "protobuf-codec"] }
+warp = { version = "0.3.4", optional = true }
+tracing-flame = "0.2.0"
+tracing-subscriber = "0.3.17"
 
 [dependencies.clap]
 version = "4"

--- a/policy-controller/Dockerfile-gnu
+++ b/policy-controller/Dockerfile-gnu
@@ -1,0 +1,19 @@
+FROM --platform=$BUILDPLATFORM ghcr.io/linkerd/dev:v40-rust as controller
+ARG BUILD_TYPE="debug"
+WORKDIR /build
+RUN mkdir -p target/bin
+COPY Cargo.toml Cargo.lock .
+COPY policy-controller policy-controller
+RUN cargo new policy-test --lib
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo fetch
+ARG TARGETARCH
+RUN --mount=type=cache,target=target \
+    --mount=type=cache,target=/usr/local/cargo/registry \
+    target=x86_64-unknown-linux-gnu  && \
+    just-cargo profile=$BUILD_TYPE target=$target build --features pprof --package=linkerd-policy-controller && \
+    mv "target/$target/$BUILD_TYPE/linkerd-policy-controller" /tmp/
+
+FROM gcr.io/distroless/cc as runtime
+COPY --from=controller /tmp/linkerd-policy-controller /bin/
+ENTRYPOINT ["/bin/linkerd-policy-controller"]

--- a/policy-controller/k8s/status/src/index.rs
+++ b/policy-controller/k8s/status/src/index.rs
@@ -18,6 +18,8 @@ use tokio::{
     },
     time::{self, Duration},
 };
+use tracing::info_span;
+use tracing::Instrument;
 
 pub(crate) const POLICY_API_GROUP: &str = "policy.linkerd.io";
 const POLICY_API_VERSION: &str = "policy.linkerd.io/v1alpha1";
@@ -159,24 +161,27 @@ impl Index {
         let mut claims = index.read().claims.clone();
 
         loop {
-            tokio::select! {
-                res = claims.changed() => {
-                    res.expect("Claims watch must not be dropped");
-                    tracing::debug!("Lease holder has changed");
+            async {
+                tokio::select! {
+                    res = claims.changed() => {
+                        res.expect("Claims watch must not be dropped");
+                        tracing::debug!("Lease holder has changed");
+                    }
+                    _ = time::sleep(Duration::from_secs(10)) => {}
                 }
-                _ = time::sleep(Duration::from_secs(10)) => {}
-            }
 
-            // The claimant has changed, or we should attempt to reconcile all
-            // HTTPRoutes to account for any errors. In either case, we should
-            // only proceed if we are the current leader.
-            let claims = claims.borrow_and_update();
-            let index = index.read();
-            if !claims.is_current_for(&index.name) {
-                continue;
+                // The claimant has changed, or we should attempt to reconcile all
+                // HTTPRoutes to account for any errors. In either case, we should
+                // only proceed if we are the current leader.
+                let claims = claims.borrow_and_update();
+                let index = index.read();
+                if claims.is_current_for(&index.name) {
+                    tracing::debug!(%index.name, "Lease holder reconciling cluster");
+                    index.reconcile();
+                }
             }
-            tracing::debug!(%index.name, "Lease holder reconciling cluster");
-            index.reconcile();
+            .instrument(info_span!("lease reconciliation loop"))
+            .await;
         }
     }
 

--- a/policy-controller/src/lib.rs
+++ b/policy-controller/src/lib.rs
@@ -3,6 +3,10 @@
 mod admission;
 pub mod index_list;
 pub use self::admission::Admission;
+
+#[cfg(feature = "pprof")]
+pub mod profiling;
+
 use anyhow::Result;
 use linkerd_policy_controller_core::inbound::{
     DiscoverInboundServer, InboundServer, InboundServerStream,

--- a/policy-controller/src/main.rs
+++ b/policy-controller/src/main.rs
@@ -87,10 +87,14 @@ struct Args {
 
     #[clap(long)]
     default_opaque_ports: String,
+
+    #[clap(long, action = clap::ArgAction::Set)]
+    enable_pprof: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    #![allow(unused_variables)]
     let Args {
         admin,
         client,
@@ -107,7 +111,13 @@ async fn main() -> Result<()> {
         control_plane_namespace,
         probe_networks,
         default_opaque_ports,
+        enable_pprof,
     } = Args::parse();
+
+    #[cfg(feature = "pprof")]
+    if enable_pprof {
+        linkerd_policy_controller::profiling::init();
+    }
 
     let server = if admission_controller_disabled {
         None

--- a/policy-controller/src/profiling.rs
+++ b/policy-controller/src/profiling.rs
@@ -1,0 +1,138 @@
+use pprof::{protos::Message, ProfilerGuardBuilder, Report};
+use serde::{Deserialize, Serialize};
+use std::fmt::Write;
+use std::sync::Arc;
+use tracing_flame::FlameLayer;
+use tracing_subscriber::{fmt, prelude::*, Registry};
+use warp::{http::Response, http::StatusCode, Filter};
+
+const PPROF_PORT: u16 = 8081;
+
+#[derive(Deserialize, Serialize)]
+struct QueryParams {
+    format: String,
+}
+
+struct MyReport(Report);
+
+impl MyReport {
+    pub fn folded<W>(&self, mut writer: W) -> Result<(), std::io::Error>
+    where
+        W: std::io::Write,
+    {
+        let lines: Vec<String> = self
+            .0
+            .data
+            .iter()
+            .map(|(key, value)| {
+                let mut line = key.thread_name_or_id();
+                line.push(';');
+
+                for frame in key.frames.iter().rev() {
+                    for symbol in frame.iter().rev() {
+                        write!(&mut line, "{};", symbol).unwrap();
+                    }
+                }
+
+                line.pop().unwrap_or_default();
+                write!(&mut line, " {}", value).unwrap();
+
+                line
+            })
+            .collect();
+
+        for line in lines {
+            writeln!(writer, "{}", line)?;
+        }
+
+        Ok(())
+    }
+}
+
+pub fn init() {
+    let guard = Arc::new(
+        ProfilerGuardBuilder::default()
+            .frequency(1000)
+            .blocklist(&["libc", "libgcc", "pthread", "vdso"])
+            .build()
+            .unwrap(),
+    );
+
+    let (flame_layer, flame_guard) = FlameLayer::with_file("/tmp/tracing.folded").unwrap();
+    let flame_guard = Arc::new(flame_guard);
+    let fmt_layer = fmt::Layer::default();
+    let subscriber = Registry::default().with(fmt_layer).with(flame_layer);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("Failed to set the default subscriber");
+
+    let opt_query = warp::query::<QueryParams>()
+        .map(Some)
+        .or_else(|_| async { Ok::<(Option<QueryParams>,), std::convert::Infallible>((None,)) });
+
+    let pprof_report_endpoint =
+        warp::path("pprof")
+            .and(opt_query)
+            .map(move |params: Option<QueryParams>| {
+                let report = guard.report().build().unwrap();
+
+                match params {
+                    Some(obj) => {
+                        if obj.format == "flamegraph" {
+                            let mut file = Vec::new();
+                            report.flamegraph(&mut file).unwrap();
+                            Response::builder()
+                                .header("content-type", "image/svg+xml")
+                                .body(file)
+                                .unwrap()
+                        } else if obj.format == "proto" {
+                            let mut file = Vec::new();
+                            let profile = report.pprof().unwrap();
+                            profile.write_to_vec(&mut file).unwrap();
+                            Response::builder()
+                                .header("content-type", "application/octet-stream")
+                                .header("content-disposition", "attachment; filename=profile.pb")
+                                .body(file)
+                                .unwrap()
+                        } else if obj.format == "folded" {
+                            let my_report = MyReport(report);
+                            let mut file = Vec::new();
+                            my_report.folded(&mut file).unwrap();
+                            Response::builder()
+                                .header("content-type", "text/plain")
+                                .header(
+                                    "content-disposition",
+                                    "attachment; filename=profile.folded",
+                                )
+                                .body(file)
+                                .unwrap()
+                        } else if obj.format == "tracing-flamegraph" {
+                            flame_guard.flush().unwrap();
+                            let file = std::fs::read("/tmp/tracing.folded").unwrap();
+                            Response::builder()
+                                .header("content-type", "text/plain")
+                                .header(
+                                    "content-disposition",
+                                    "attachment; filename=profile.folded",
+                                )
+                                .body(file)
+                                .unwrap()
+                        } else {
+                            Response::builder()
+                                .status(StatusCode::NOT_FOUND)
+                                .body(Vec::from("404 Not Found"))
+                                .unwrap()
+                        }
+                    }
+                    None => Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .body(Vec::from("Failed to decode query param."))
+                        .unwrap(),
+                }
+            });
+
+    tokio::spawn(async move {
+        warp::serve(pprof_report_endpoint)
+            .run(([0, 0, 0, 0], PPROF_PORT))
+            .await;
+    });
+}


### PR DESCRIPTION
It gives support for rust dynamic profiling using [pprof-rs](https://github.com/tikv/pprof-rs/) and [tracing-flame](https://github.com/tokio-rs/tracing/tree/master/tracing-flame). It exposes multiple endpoints to support for flamegraph, protobuf, stack folded lines and tracing-flamegraph. 
It will be enabled using `--set enablePprof=true`.